### PR TITLE
Fix compose view bug when sending a post, Also add feature to allow for the extraction of the twitter refresh token from delivery message. With other bug fixes an improvements

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -3563,6 +3563,58 @@
         }
       }
     },
+    "Got it" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "حسناً"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verstanden"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entendido"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "متوجه شدم"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compris"
+          }
+        },
+        "sn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ndanzwisisa"
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nimeelewa"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anladım"
+          }
+        }
+      }
+    },
     "Great!" : {
       "localizations" : {
         "ar" : {
@@ -4012,6 +4064,12 @@
             "value" : "Langue"
           }
         },
+        "sn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mutauro"
+          }
+        },
         "sw" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4074,6 +4132,58 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nasıl çalıştığını öğrenin"
+          }
+        }
+      }
+    },
+    "Load Platforms" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تحميل المنصات"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Plattformen laden"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cargar plataformas"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "بارگیری پلتفرم‌ها"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Charger les plateformes"
+          }
+        },
+        "sn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rodha Mapuratifomu"
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pakia Majukwaa"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Platformları Yükle"
           }
         }
       }
@@ -4909,6 +5019,58 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Henüz kaydedilmiş çevrimiçi platform yok..."
+          }
+        }
+      }
+    },
+    "No online platforms saved yet... You can save more platforms below" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : " لا توجد منصات محفوظة حتى الآن... يمكنك حفظ المزيد من المنصات أدناه"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Noch keine Online-Plattformen gespeichert... Sie können weitere Plattformen unten speichern"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aún no hay plataformas en línea guardadas... Puedes guardar más plataformas abajo"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "هنوز هیچ پلتفرم آنلاینی ذخیره نشده... می‌توانید پلتفرم‌های بیشتری در زیر ذخیره کنید"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucune plateforme en ligne sauvegardée pour le moment... Vous pouvez sauvegarder plus de plateformes ci-dessous"
+          }
+        },
+        "sn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hapana mapuratifomu epamhepo akachengetwa... Unogona kuchengetedza mamwe mapuratifomu pazasi"
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hakuna majukwaa ya mtandaoni yamehifadhiwa bado... Unaweza kuhifadhi majukwaa zaidi hapa chini"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Henüz kaydedilmiş çevrimiçi platform yok... Aşağıda daha fazla platform kaydedebilirsiniz"
           }
         }
       }
@@ -8174,6 +8336,58 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gateway Client Güncelle"
+          }
+        }
+      }
+    },
+    "Update Twitter" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تحديث تويتر"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Twitter aktualisieren"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualizar Twitter"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "به‌روزرسانی توییتر"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mettre à jour Twitter"
+          }
+        },
+        "sn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gadzirisa Twitter"
+          }
+        },
+        "sw" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sasisha Twitter"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Twitter'ı Güncelle"
           }
         }
       }

--- a/SMSWithoutBorders-Production/Commons/base64Extractor.swift
+++ b/SMSWithoutBorders-Production/Commons/base64Extractor.swift
@@ -1,0 +1,102 @@
+//
+//  base64Extractor.swift
+//  SMSWithoutBorders-Production
+//
+//  Created by Nui Lewis on 12/06/2025.
+//
+
+
+import Foundation
+
+private func extractBase64Strings(from text: String, minLength: Int = 20) -> [String] {
+    let base64Pattern = #"[A-Za-z0-9+/]{4,}={0,2}"#
+    
+    guard let regex = try? NSRegularExpression(pattern: base64Pattern) else {
+        return []
+    }
+    
+    let range = NSRange(text.startIndex..., in: text)
+    let matches = regex.matches(in: text, options:[], range: range)
+    
+    var validBase64Strings: [String] = []
+    
+    
+    for match in matches {
+        guard let matchRange = Range(match.range, in: text) else {continue}
+        let candidate = String(text[matchRange])
+        
+        
+        // Check if its a valideBase64
+        if isValidBase64(candidate) && candidate.count >= minLength {
+            validBase64Strings.append(candidate)
+        }
+    }
+    
+    return validBase64Strings
+}
+
+private func extractLongestBase64(from text: String, minLength: Int = 20) -> String? {
+    let base64Strings = extractBase64Strings(from: text, minLength: minLength)
+    return base64Strings.max(by: {$0.count < $1.count})
+}
+
+private func isValidBase64(_ string: String) -> Bool {
+    let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+    
+    // Check basic format requirements
+    guard !trimmed.isEmpty, trimmed.count >= 4 else {
+        return false
+    }
+    
+    // Check lenth - Base64 should be divisible by 4 (with padding)
+    let paddingCount = trimmed.suffix(2).filter({ $0 == "=" }).count
+    let withoutPadding = trimmed.count - paddingCount
+    
+    guard (trimmed.count % 4 == 0) || paddingCount > 0 else {
+        return false
+    }
+    
+    // Validate character set
+    let base64CharSet = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=")
+    guard trimmed.unicodeScalars.allSatisfy({ base64CharSet.contains($0) }) else {
+        return false
+    }
+    
+    // Validate padding rules
+    if paddingCount > 0 {
+        //Padding can only be at the end
+        let paddingIndex = trimmed.firstIndex(of: "=")
+        let remainingCharacters = trimmed[paddingIndex!...]
+        guard remainingCharacters.allSatisfy({ $0 == "=" }) else {
+            return false
+        }
+        
+        guard paddingCount <= 2 else {
+            return false
+        }
+    }
+    
+    // Try to decode to verify its valid Base64
+    guard Data(base64Encoded: trimmed) != nil else {
+        return false
+    }
+    
+    return true
+}
+
+
+func extractEncryptedText(from input: String, minLength: Int = 20) -> String? {
+    return extractLongestBase64(from: input, minLength: minLength)
+}
+
+func decodeBase64String(from base64String: String) -> String {
+    let decodedString = String(
+        data: Data(base64Encoded: base64String) ?? Data(), encoding: .utf8)
+    
+    if let result = decodedString, !result.isEmpty {
+        print("Successfully decoded the Base64 string: \(result)")
+        return result;
+    }
+    return "";
+}
+

--- a/SMSWithoutBorders-Production/Datastore.xcdatamodeld/PlatformModels.xcdatamodel/contents
+++ b/SMSWithoutBorders-Production/Datastore.xcdatamodeld/PlatformModels.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23788" systemVersion="24E263" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23507" systemVersion="24F74" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="GatewayClientsEntity" representedClassName="GatewayClientsEntity" syncable="YES" codeGenerationType="class">
         <attribute name="country" optional="YES" attributeType="String"/>
         <attribute name="lastPublishedDate" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
@@ -33,11 +33,11 @@
     </entity>
     <entity name="PlatformsEntity" representedClassName="PlatformsEntity" syncable="YES" codeGenerationType="class">
         <attribute name="image" optional="YES" attributeType="Binary"/>
-        <attribute name="name" optional="YES" attributeType="String"/>
-        <attribute name="protocol_type" optional="YES" attributeType="String"/>
-        <attribute name="service_type" optional="YES" attributeType="String"/>
-        <attribute name="shortcode" optional="YES" attributeType="String"/>
-        <attribute name="support_url_scheme" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="protocol_type" attributeType="String"/>
+        <attribute name="service_type" attributeType="String"/>
+        <attribute name="shortcode" attributeType="String"/>
+        <attribute name="support_url_scheme" attributeType="Boolean" usesScalarValueType="YES"/>
         <uniquenessConstraints>
             <uniquenessConstraint>
                 <constraint value="name"/>
@@ -48,11 +48,12 @@
         <attribute name="data" optional="YES" attributeType="Binary"/>
     </entity>
     <entity name="StoredPlatformsEntity" representedClassName="StoredPlatformsEntity" syncable="YES" codeGenerationType="class">
-        <attribute name="access_token" optional="YES" attributeType="String"/>
-        <attribute name="account" optional="YES" attributeType="String"/>
-        <attribute name="id" optional="YES" attributeType="String"/>
-        <attribute name="name" optional="YES" attributeType="String"/>
-        <attribute name="refresh_token" optional="YES" attributeType="String"/>
+        <attribute name="access_token" attributeType="String" defaultValueString=""/>
+        <attribute name="account" attributeType="String"/>
+        <attribute name="id" attributeType="String"/>
+        <attribute name="is_stored_on_device" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="refresh_token" attributeType="String" defaultValueString=""/>
         <uniquenessConstraints>
             <uniquenessConstraint>
                 <constraint value="id"/>

--- a/SMSWithoutBorders-Production/Handlers/PlatformsEntityHandlers.swift
+++ b/SMSWithoutBorders-Production/Handlers/PlatformsEntityHandlers.swift
@@ -10,3 +10,91 @@ import CoreData
 
 struct DownloadContent {
 }
+
+// MARK: - Platforms Model
+struct Platform: Identifiable {
+    let name: String
+    let protocolType: Publisher.ProtocolTypes
+    let serviceType: Publisher.ServiceTypes
+    let shortcode: String
+    let supportUrlScheme: Bool
+    let imageData: Data?
+
+    var id: String { name }
+
+    init(
+        name: String, protocolType: Publisher.ProtocolTypes, serviceType: Publisher.ServiceTypes,
+        shortcode: String, supportUrlScheme: Bool, imageData: Data? = nil
+    ) {
+        self.name = name
+        self.protocolType = protocolType
+        self.serviceType = serviceType
+        self.shortcode = shortcode
+        self.supportUrlScheme = supportUrlScheme
+        self.imageData = imageData
+    }
+
+    func copyWith(
+        name: String? = nil,
+        protocolType: Publisher.ProtocolTypes? = nil,
+        serviceType: Publisher.ServiceTypes? = nil,
+        shortcode: String? = nil,
+        supportUrlScheme: Bool? = nil,
+        imageData: Data? = nil
+    ) -> Platform {
+        return Platform(
+            name: name ?? self.name,
+            protocolType: protocolType ?? self.protocolType,
+            serviceType: serviceType ?? self.serviceType,
+            shortcode: shortcode ?? self.shortcode,
+            supportUrlScheme: supportUrlScheme ?? self.supportUrlScheme,
+            imageData: imageData ?? self.imageData
+        )
+    }
+
+    static func fromEntity(_ entity: PlatformsEntity) throws -> Platform {
+        guard let entityName = entity.name, !entityName.isEmpty else {
+            throw CustomError(
+                message: "Invalid Entity: Platform name is nil or empty")
+        }
+
+        return Platform(
+            name: entityName,
+            protocolType: Publisher.ProtocolTypes(rawValue: entity.protocol_type ?? "oauth2") ?? Publisher.ProtocolTypes.OAUTH2,
+            serviceType: Publisher.ServiceTypes(rawValue: entity.service_type ?? "text") ?? Publisher.ServiceTypes.TEXT,
+            shortcode: entity.shortcode ?? "",
+            supportUrlScheme: entity.support_url_scheme,
+            imageData: entity.image
+        )
+    }
+    
+    static var sample: Platform = Platform(
+        name: "gmail",
+        protocolType:  Publisher.ProtocolTypes.OAUTH2,
+        serviceType:  Publisher.ServiceTypes.EMAIL,
+        shortcode:  "g",
+        supportUrlScheme: true
+    )
+
+}
+
+
+extension PlatformsEntity {
+    func toStruct() -> Platform? {
+        guard let entityName = self.name, !entityName.isEmpty else {
+            print("Invalid Entity: Platform name is nil or empty")
+            return nil
+//            throw CustomError(
+//                message: "Invalid Entity: Platform name is nil or empty")
+        }
+
+        return Platform(
+            name: entityName,
+            protocolType: Publisher.ProtocolTypes(rawValue: self.protocol_type ?? "oauth2") ?? Publisher.ProtocolTypes.OAUTH2,
+            serviceType: Publisher.ServiceTypes(rawValue: self.service_type ?? "text") ?? Publisher.ServiceTypes.TEXT,
+            shortcode: self.shortcode ?? "",
+            supportUrlScheme: self.support_url_scheme,
+            imageData: self.image
+        )
+    }
+}

--- a/SMSWithoutBorders-Production/Handlers/StoredPlatformEntityHandler.swift
+++ b/SMSWithoutBorders-Production/Handlers/StoredPlatformEntityHandler.swift
@@ -1,0 +1,102 @@
+//
+//  StoredPlatformEntityHandler.swift
+//  SMSWithoutBorders-Production
+//
+//  Created by Nui Lewis on 13/06/2025.
+//
+
+
+// MARK: - Stored Platform Account
+struct StoredPlatform: Identifiable {
+    let id: String
+    let name: String
+    let account: String
+    let isStoredOnDevice: Bool
+    let accessToken: String?
+    let refreshToken: String?
+    //let idToken: String?
+
+    init(
+        id: String, name: String,
+        account: String,
+        isStoredOnDevice: Bool,
+        accessToken: String?,
+        refreshToken: String?
+    ) {
+        self.id = id
+        self.name = name
+        self.account = account
+        self.isStoredOnDevice = isStoredOnDevice
+        self.accessToken = accessToken
+        self.refreshToken = refreshToken
+    }
+
+    func copyWith(
+        name: String?,
+        account: String?,
+        isStoredOnDevice: Bool?,
+        accessToken: String?,
+        refreshToken: String?, idToken: String?
+    ) -> StoredPlatform {
+        return StoredPlatform(
+            id: self.id,
+            name: name ?? self.name,
+            account: account ?? self.account,
+            isStoredOnDevice: isStoredOnDevice ?? self.isStoredOnDevice,
+            accessToken: accessToken ?? self.accessToken,
+            refreshToken: refreshToken ?? self.refreshToken
+        )
+    }
+
+    static func fromEntity(_ entity: StoredPlatformsEntity) throws
+        -> StoredPlatform
+    {
+        guard let entityId = entity.id, !entityId.isEmpty else {
+            throw CustomError(message: "Invalid Entity: Entity ID is nil")
+        }
+
+        // TODO: Probably do the decryption here
+
+        return StoredPlatform(
+            id: entityId,
+            name: entity.name ?? "",
+            account: entity.account ?? "",
+            isStoredOnDevice: entity.is_stored_on_device,
+            accessToken: entity.access_token,
+            refreshToken: entity.refresh_token
+        )
+    }
+
+}
+
+extension StoredPlatform {
+    var tokensExists: Bool {
+        if let aToken = accessToken, let rToken = refreshToken {
+            return !aToken.isEmpty && !rToken.isEmpty
+        } else {
+            return false
+        }
+    }
+    
+    var isMissing: Bool {
+      return  self.isStoredOnDevice && !self.tokensExists
+    }
+}
+
+
+extension StoredPlatformsEntity {
+   func toStruct() throws -> StoredPlatform {
+       guard let id = self.id, !id.isEmpty else {
+           throw CustomError(message: "Invalid Entity: Stored Platform id is nil or empty")
+       }
+       
+       return StoredPlatform(
+        id: self.id ?? "",
+        name: self.name ?? "",
+        account: self.account ?? "",
+        isStoredOnDevice: self.is_stored_on_device,
+        accessToken: self.access_token ?? "",
+        refreshToken: self.refresh_token ?? ""
+       )
+    }
+}

--- a/SMSWithoutBorders-Production/Modules/Publisher.swift
+++ b/SMSWithoutBorders-Production/Modules/Publisher.swift
@@ -324,10 +324,12 @@ class Publisher {
 
                 // 4. Save changes (outside the if/else)
                 if context.hasChanges {
-                    do {
-                        try context.save()
-                    } catch {
-                        print("[Publisher] Failed save download image: \(error) \(error.localizedDescription)")
+                    DispatchQueue.main.async {
+                        do {
+                            try context.save()
+                        } catch {
+                            print("[Publisher] Failed save download image: \(error) \(error.localizedDescription)")
+                        }
                     }
                 }
 

--- a/SMSWithoutBorders-Production/Modules/Vault.swift
+++ b/SMSWithoutBorders-Production/Modules/Vault.swift
@@ -543,9 +543,7 @@ struct Vault {
                 let platformId = Vault.deriveUniqueKey(
                     platformName: platform.platform,
                     accountIdentifier: platform.accountIdentifier
-                )
-                print("Vault. is platform \(platform.accountIdentifier) stored on device: \(platform.isStoredOnDevice)")
-                
+                )                
                 do {
                     try Vault.saveStoredPlatform(
                          context: context,

--- a/SMSWithoutBorders-Production/Modules/Vault.swift
+++ b/SMSWithoutBorders-Production/Modules/Vault.swift
@@ -16,27 +16,27 @@ import SwiftUI
 import SwobDoubleRatchet
 
 struct Vault {
-
+    
     public static var VAULT_LONG_LIVED_TOKEN =
-        "COM.AFKANERD.RELAYSMS.VAULT_LONG_LIVED_TOKEN"
+    "COM.AFKANERD.RELAYSMS.VAULT_LONG_LIVED_TOKEN"
     public static var VAULT_PHONE_NUMBER =
-        "COM.AFKANERD.RELAYSMS.VAULT_PHONE_NUMBER"
+    "COM.AFKANERD.RELAYSMS.VAULT_PHONE_NUMBER"
     public static var VAULT_DEVICE_ID = "COM.AFKANERD.RELAYSMS.VAULT_DEVICE_ID"
     public static var DEVICE_PUBLIC_KEY_KEYSTOREALIAS =
-        "COM.AFKANERD.DEVICE_PUBLIC_KEY_KEYSTOREALIAS"
-
+    "COM.AFKANERD.DEVICE_PUBLIC_KEY_KEYSTOREALIAS"
+    
     @AppStorage(SettingsKeys.SETTINGS_STORE_PLATFORMS_ON_DEVICE)
     var shouldStorePlatformsOnDevice: Bool = false
-
+    
     enum Exceptions: Error {
         case requestNotOK(status: GRPCStatus)
         case unauthenticatedLLT(status: GRPCStatus)
     }
-
+    
     var channel: ClientConnection?
     var callOptions: CallOptions?
     var vaultEntityStub: Vault_V1_EntityNIOClient?
-
+    
     init() {
         channel = GRPCHandler.getChannelVault()
         let logger = Logger(
@@ -47,7 +47,7 @@ struct Vault {
             defaultCallOptions: callOptions!
         )
     }
-
+    
     func createEntity(
         context: NSManagedObjectContext,
         phoneNumber: String,
@@ -60,11 +60,11 @@ struct Vault {
         let clientDeviceIDPrivateKey = try SecurityCurve25519.generateKeyPair()
         let clientDeviceIDPubKey = clientDeviceIDPrivateKey.publicKey
             .rawRepresentation.base64EncodedString()
-
+        
         let clientPublishPrivateKey = try SecurityCurve25519.generateKeyPair()
         let clientPublishPubKey = clientPublishPrivateKey.publicKey
             .rawRepresentation.base64EncodedString()
-
+        
         let entityCreationRequest: Vault_V1_CreateEntityRequest = .with {
             $0.countryCode = countryCode
             $0.phoneNumber = phoneNumber
@@ -73,7 +73,7 @@ struct Vault {
             $0.clientDeviceIDPubKey = clientDeviceIDPubKey
             if ownershipResponse != nil && !ownershipResponse!.isEmpty {
                 $0.ownershipProofResponse = ownershipResponse!
-
+                
                 UserDefaults.standard.set(
                     clientPublishPrivateKey.publicKey.rawRepresentation.bytes,
                     forKey: Bridges.CLIENT_PUBLIC_KEY_KEYSTOREALIAS
@@ -82,41 +82,41 @@ struct Vault {
         }
         
         print("[Vault] Create entity request: \(entityCreationRequest)")
-
+        
         let call = vaultEntityStub!.createEntity(entityCreationRequest)
         var response: Vault_V1_CreateEntityResponse
-
+        
         do {
             response = try call.response.wait()
             let status = try call.status.wait()
             
             print("[Vault] Create entity response: \(entityCreationRequest)")
-
-            #if DEBUG
-                print("[Vault] status code - raw value: \(status.code.rawValue)")
-                print("[Vault] response: \(response)")
-                print("[Vault] status code - description: \(status.code.description)")
-                print("[Vault] status code - isOk: \(status.isOk)")
-            #endif
-
+            
+#if DEBUG
+            print("[Vault] status code - raw value: \(status.code.rawValue)")
+            print("[Vault] response: \(response)")
+            print("[Vault] status code - description: \(status.code.description)")
+            print("[Vault] status code - isOk: \(status.isOk)")
+#endif
+            
             if !status.isOk {
                 throw Exceptions.requestNotOK(status: status)
             }
-
+            
             if !response.requiresOwnershipProof {
                 UserDefaults.standard.set(
                     [UInt8](Data(base64Encoded: response.serverPublishPubKey)!),
                     forKey: Publisher.PUBLISHER_SERVER_PUBLIC_KEY
                 )
-
-                #if DEBUG
-                    print(
-                        "[Vault] Peer publish: \(response.serverPublishPubKey) : \(response.serverPublishPubKey.count)"
-                    )
-                    print(
-                        "[Vault] Peer pubkey: \(response.serverDeviceIDPubKey) : \(response.serverDeviceIDPubKey.count)"
-                    )
-                #endif
+                
+#if DEBUG
+                print(
+                    "[Vault] Peer publish: \(response.serverPublishPubKey) : \(response.serverPublishPubKey.count)"
+                )
+                print(
+                    "[Vault] Peer pubkey: \(response.serverDeviceIDPubKey) : \(response.serverDeviceIDPubKey.count)"
+                )
+#endif
                 try Vault.derivceStoreLLT(
                     lltEncoded: response.longLivedToken,
                     phoneNumber: phoneNumber,
@@ -126,7 +126,7 @@ struct Vault {
                             Data(base64Encoded: response.serverDeviceIDPubKey)!)
                     )
                 )
-
+                
                 try Vault.derivceStorePublishSharedSecret(
                     context: context,
                     clientPublishPrivateKey: clientPublishPrivateKey,
@@ -141,7 +141,7 @@ struct Vault {
         }
         return response
     }
-
+    
     func authenticateEntity(
         context: NSManagedObjectContext,
         phoneNumber: String,
@@ -151,11 +151,11 @@ struct Vault {
         let clientDeviceIDPrivateKey = try SecurityCurve25519.generateKeyPair()
         let clientDeviceIDPubKey = clientDeviceIDPrivateKey.publicKey
             .rawRepresentation.base64EncodedString()
-
+        
         let clientPublishPrivateKey = try SecurityCurve25519.generateKeyPair()
         let clientPublishPubKey = clientPublishPrivateKey.publicKey
             .rawRepresentation.base64EncodedString()
-
+        
         let authenticateEntityRequest: Vault_V1_AuthenticateEntityRequest =
             .with {
                 $0.phoneNumber = phoneNumber
@@ -164,7 +164,7 @@ struct Vault {
                 $0.clientDeviceIDPubKey = clientDeviceIDPubKey
                 if ownershipResponse != nil {
                     $0.ownershipProofResponse = ownershipResponse!
-
+                    
                     UserDefaults.standard.set(
                         clientPublishPrivateKey.publicKey.rawRepresentation
                             .bytes,
@@ -172,30 +172,30 @@ struct Vault {
                     )
                 }
             }
-
+        
         let call = vaultEntityStub!.authenticateEntity(
             authenticateEntityRequest)
         let response: Vault_V1_AuthenticateEntityResponse
         do {
             response = try call.response.wait()
             let status = try call.status.wait()
-
+            
             print("[Vault] status code - raw value: \(status.code.rawValue)")
             print("[Vault] status code - description: \(status.code.description)")
             print("[Vault] status code - isOk: \(status.isOk)")
-
+            
             if !status.isOk {
                 throw Exceptions.requestNotOK(status: status)
             }
-
+            
             if !response.requiresOwnershipProof {
                 print("[Vault] Here lies the Ad: \(response.serverPublishPubKey)\n")
-
+                
                 UserDefaults.standard.set(
                     [UInt8](Data(base64Encoded: response.serverPublishPubKey)!),
                     forKey: Publisher.PUBLISHER_SERVER_PUBLIC_KEY
                 )
-
+                
                 try Vault.derivceStoreLLT(
                     lltEncoded: response.longLivedToken,
                     phoneNumber: phoneNumber,
@@ -205,7 +205,7 @@ struct Vault {
                             Data(base64Encoded: response.serverDeviceIDPubKey)!)
                     )
                 )
-
+                
                 try Vault.derivceStorePublishSharedSecret(
                     context: context,
                     clientPublishPrivateKey: clientPublishPrivateKey,
@@ -220,7 +220,7 @@ struct Vault {
         }
         return response
     }
-
+    
     func listStoredEntityToken(
         longLiveToken: String, migrateToDevice: Bool = false
     ) throws -> Vault_V1_ListEntityStoredTokensResponse {
@@ -231,7 +231,7 @@ struct Vault {
             $0.longLivedToken = longLiveToken
             $0.migrateToDevice = migrateToDevice
         }
-
+        
         print("[Vault] List Entity StoredToken Request: \(listEntityRequest)")
         
         let call = vaultEntityStub!.listEntityStoredTokens(listEntityRequest)
@@ -241,11 +241,11 @@ struct Vault {
             let status = try call.status.wait()
             
             print("[Vault] List Entity StoredToken Response: \(response)")
-
+            
             print("[Vault] status code - raw value: \(status.code.rawValue)")
             print("[Vault] status code - description: \(status.code.description)")
             print("[Vault] status code - isOk: \(status.isOk)")
-
+            
             if !status.isOk {
                 if status.code.rawValue == 16 {
                     throw Exceptions.unauthenticatedLLT(status: status)
@@ -258,7 +258,7 @@ struct Vault {
         }
         return response
     }
-
+    
     func recoverPassword(
         context: NSManagedObjectContext,
         phoneNumber: String,
@@ -269,11 +269,11 @@ struct Vault {
         let clientDeviceIDPrivateKey = try SecurityCurve25519.generateKeyPair()
         let clientDeviceIDPubKey = clientDeviceIDPrivateKey.publicKey
             .rawRepresentation.base64EncodedString()
-
+        
         let clientPublishPrivateKey = try SecurityCurve25519.generateKeyPair()
         let clientPublishPubKey = clientPublishPrivateKey.publicKey
             .rawRepresentation.base64EncodedString()
-
+        
         let recoverPasswordRequest: Vault_V1_ResetPasswordRequest = .with {
             $0.phoneNumber = phoneNumber
             $0.newPassword = newPassword
@@ -281,7 +281,7 @@ struct Vault {
             $0.clientDeviceIDPubKey = clientDeviceIDPubKey
             if ownershipResponse != nil {
                 $0.ownershipProofResponse = ownershipResponse!
-
+                
                 UserDefaults.standard.set(
                     clientPublishPrivateKey.publicKey.rawRepresentation.bytes,
                     forKey: Bridges.CLIENT_PUBLIC_KEY_KEYSTOREALIAS
@@ -290,7 +290,7 @@ struct Vault {
         }
         
         print("[Vault] Recovering password request: \(recoverPasswordRequest)")
-
+        
         let call = vaultEntityStub!.resetPassword(recoverPasswordRequest)
         let response: Vault_V1_ResetPasswordResponse
         do {
@@ -298,21 +298,21 @@ struct Vault {
             let status = try call.status.wait()
             
             print("[Vault] Recovering password response: \(response)")
-
+            
             print("[Vault] status code - raw value: \(status.code.rawValue)")
             print("[Vault] status code - description: \(status.code.description)")
             print("[Vault] status code - isOk: \(status.isOk)")
-
+            
             if !status.isOk {
                 throw Exceptions.requestNotOK(status: status)
             }
-
+            
             if !response.requiresOwnershipProof {
                 UserDefaults.standard.set(
                     [UInt8](Data(base64Encoded: response.serverPublishPubKey)!),
                     forKey: Publisher.PUBLISHER_SERVER_PUBLIC_KEY
                 )
-
+                
                 try Vault.derivceStoreLLT(
                     lltEncoded: response.longLivedToken,
                     phoneNumber: phoneNumber,
@@ -322,7 +322,7 @@ struct Vault {
                             Data(base64Encoded: response.serverDeviceIDPubKey)!)
                     )
                 )
-
+                
                 try Vault.derivceStorePublishSharedSecret(
                     context: context,
                     clientPublishPrivateKey: clientPublishPrivateKey,
@@ -337,24 +337,24 @@ struct Vault {
         }
         return response
     }
-
+    
     private func deleteEntity(
         context: NSManagedObjectContext, longLiveToken: String
     ) throws -> Vault_V1_DeleteEntityResponse {
         let deleteEntityRequest: Vault_V1_DeleteEntityRequest = .with {
             $0.longLivedToken = longLiveToken
         }
-
+        
         let call = vaultEntityStub!.deleteEntity(deleteEntityRequest)
         let response: Vault_V1_DeleteEntityResponse
         do {
             response = try call.response.wait()
             let status = try call.status.wait()
-
+            
             print("[Vault] status code - raw value: \(status.code.rawValue)")
             print("[Vault] status code - description: \(status.code.description)")
             print("[Vault] status code - isOk: \(status.isOk)")
-
+            
             if !status.isOk {
                 if status.code.rawValue == 16 {
                     throw Exceptions.unauthenticatedLLT(status: status)
@@ -362,16 +362,16 @@ struct Vault {
                 print(status)
                 throw Exceptions.requestNotOK(status: status)
             }
-
+            
             try Vault.resetKeystore(context: context)
-
+            
         } catch {
             print("[Vault] Some error came back: \(error)")
             throw error
         }
         return response
     }
-
+    
     public static func completeDeleteEntity(
         context: NSManagedObjectContext,
         longLiveToken: String,
@@ -379,7 +379,7 @@ struct Vault {
         platforms: FetchedResults<PlatformsEntity>
     ) throws {
         let vault = Vault()
-
+        
         do {
             let publisher = Publisher()
             for storedTokenEntity in storedTokenEntities {
@@ -400,7 +400,7 @@ struct Vault {
             throw error
         }
     }
-
+    
     public static func getPublisherSharedSecret() throws -> [UInt8]? {
         do {
             let sk = try CSecurity.findInKeyChain(
@@ -412,7 +412,7 @@ struct Vault {
             throw error
         }
     }
-
+    
     public static func getLongLivedToken() throws -> String {
         do {
             let llt = try CSecurity.findInKeyChain(
@@ -424,26 +424,26 @@ struct Vault {
             throw error
         }
     }
-
+    
     public static func resetKeystore(context: NSManagedObjectContext) throws {
         CSecurity.deletePasswordFromKeychain(
             keystoreAlias: Vault.VAULT_LONG_LIVED_TOKEN)
         CSecurity.deletePasswordFromKeychain(
             keystoreAlias: Publisher.PUBLISHER_SHARED_KEY)
-
+        
         try resetStates(context: context)
-
+        
         let onboardingCompleted = UserDefaults.standard.bool(
             forKey: OnboardingView.ONBOARDING_COMPLETED)
         let defaultGatewayClient =
-            UserDefaults.standard.string(
-                forKey: GatewayClients.DEFAULT_GATEWAY_CLIENT_MSISDN)
-            ?? ""
-
+        UserDefaults.standard.string(
+            forKey: GatewayClients.DEFAULT_GATEWAY_CLIENT_MSISDN)
+        ?? ""
+        
         if let appDomain = Bundle.main.bundleIdentifier {
             UserDefaults.standard.removePersistentDomain(forName: appDomain)
         }
-
+        
         UserDefaults.standard.set(
             onboardingCompleted, forKey: OnboardingView.ONBOARDING_COMPLETED)
         if !defaultGatewayClient.isEmpty {
@@ -453,12 +453,12 @@ struct Vault {
         }
         print("[Vault] [important] keystore reset done...")
     }
-
+    
     public static func resetStates(context: NSManagedObjectContext) throws {
         let fetchRequest = NSFetchRequest<NSFetchRequestResult>(
             entityName: "StatesEntity")
         let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
-
+        
         do {
             try context.execute(deleteRequest)
             try context.save()
@@ -466,14 +466,67 @@ struct Vault {
             throw error
         }
     }
-
+    
     static func deriveUniqueKey(platformName: String, accountIdentifier: String)
-        -> String
+    -> String
     {
         return SHA256.hash(data: Data((platformName + accountIdentifier).utf8))
             .description
     }
+    
+    static func saveStoredPlatform(
+        context: NSManagedObjectContext,
+        id: String,
+        name: String,
+        account: String,
+        isStoredOnDevice: Bool,
+        accessToken: String?,
+        refreshToken: String?
+    ) throws {
 
+        guard !id.isEmpty else {
+            print("Error: StoredPlatform ID cannot be empty for upsert operation.")
+            return
+        }
+
+        let fetchRequest: NSFetchRequest<StoredPlatformsEntity> =
+            StoredPlatformsEntity.fetchRequest()
+        fetchRequest.predicate = NSPredicate(
+            format: "id == %@", id)
+
+        do {
+            let existingEntity = try context.fetch(fetchRequest).first
+            let entityToSave: StoredPlatformsEntity
+
+            if let existing = existingEntity {
+                print("Updating existing stored platform with ID: \(id)")
+                entityToSave = existing
+            } else {
+                print("Creating new stored platform with ID: \(id)")
+                entityToSave = StoredPlatformsEntity(context: context)
+                entityToSave.id = id
+            }
+
+            entityToSave.name = name
+            entityToSave.account = account
+            entityToSave.is_stored_on_device = isStoredOnDevice
+            if let icomingAccessToken = accessToken, !icomingAccessToken.isEmpty {
+                entityToSave.access_token = accessToken
+            }
+            if let icomingRefreshToken = refreshToken, !icomingRefreshToken.isEmpty {
+                entityToSave.refresh_token = refreshToken
+            }
+
+            try context.save()
+            print("Successfully saved stored platform: \(name) (ID: \(id))")
+
+        } catch {
+            print("Error saving stored platform (ID: \(id)): \(error)")
+            throw error
+        }
+
+    }
+    
     func refreshStoredTokens(
         llt: String,
         context: NSManagedObjectContext,
@@ -486,61 +539,36 @@ struct Vault {
             let addedPlatforms = try vault.listStoredEntityToken(
                 longLiveToken: llt, migrateToDevice: shouldStorePlatformsOnDevice)
             
-            var platformsToSave: [Vault_V1_Token] = []
-            print(storedTokenEntities)
-
             for platform in addedPlatforms.storedTokens {
                 let platformId = Vault.deriveUniqueKey(
                     platformName: platform.platform,
                     accountIdentifier: platform.accountIdentifier
                 )
-
-                let accessToken = platform.accountTokens["access_token"] ?? ""
-                let refreshToken = platform.accountTokens["refresh_token"] ?? ""
+                print("Vault. is platform \(platform.accountIdentifier) stored on device: \(platform.isStoredOnDevice)")
                 
-                let isStoredOnDevice = platform.isStoredOnDevice
-                if isStoredOnDevice &&
-                    accessToken.isEmpty &&
-                    storedTokenEntities != nil &&
-                    !storedTokenEntities!.contains(where: { $0.id == platformId }){
-                    missingTokens.append(platform)
+                do {
+                    try Vault.saveStoredPlatform(
+                         context: context,
+                         id: platformId,
+                         name: platform.platform,
+                         account: platform.accountIdentifier,
+                         isStoredOnDevice: platform.isStoredOnDevice,
+                         accessToken: platform.accountTokens["access_token"] ?? "",
+                         refreshToken: platform.accountTokens["refresh_token"] ?? ""
+                   )
+                } catch {
+                    print("[Vault] Failed to store platform \(platform.accountIdentifier): \(error)")
                 }
-                else {
-                    if storedTokenEntities == nil || !storedTokenEntities!.contains(where: { $0.id == platformId }){
-                        platformsToSave.append(platform)
-                    }
-                }
-            }
-            
-            
-            if !platformsToSave.isEmpty {
-                try Vault.clear(context: context)
-            }
-//            context.reset()
-            
-            print("[+] platforms to save: ", platformsToSave)
-            for platform in platformsToSave {
-                let platformId = Vault.deriveUniqueKey(
-                    platformName: platform.platform,
-                    accountIdentifier: platform.accountIdentifier
-                )
-                let storedPlatformEntity = StoredPlatformsEntity(context: context)
-                storedPlatformEntity.id = platformId
-                storedPlatformEntity.name = platform.platform
-                storedPlatformEntity.account = platform.accountIdentifier
-                storedPlatformEntity.access_token = platform.accountTokens["access_token"] ?? ""
-                storedPlatformEntity.refresh_token = platform.accountTokens["refresh_token"] ?? ""
+                
+                // Have this missingTokens thing still
+//                if platform.isStoredOnDevice &&
+//                    accessToken.isEmpty &&
+//                    storedTokenEntities != nil &&
+//                    !storedTokenEntities!.contains(where: { $0.id == platformId }){
+//                    missingTokens.append(platform)
+//                }
             }
 
-            DispatchQueue.main.async {
-                do {
-                    if context.hasChanges {
-                        try context.save()
-                    }
-                } catch {
-                    print("[Vault] Failed to save context after refreshing entities: \(error)")
-                }
-            }
         } catch Exceptions.unauthenticatedLLT(let status) {
             print("[Vault] Should delete invalid llt: \(String(describing: status.message))")
             try Vault.resetKeystore(context: context)
@@ -552,6 +580,93 @@ struct Vault {
         return missingTokens
     }
     
+
+    
+//    func refreshStoredTokens(
+//        llt: String,
+//        context: NSManagedObjectContext,
+//        storedTokenEntities: FetchedResults<StoredPlatformsEntity>?
+//    ) throws -> [Vault_V1_Token] {
+//        print("[Vault] Refreshing stored platforms...")
+//        let vault = Vault()
+//        var missingTokens: [Vault_V1_Token] = []
+//        do {
+//            let addedPlatforms = try vault.listStoredEntityToken(
+//                longLiveToken: llt, migrateToDevice: shouldStorePlatformsOnDevice)
+//            
+//            var platformsToSave: [Vault_V1_Token] = []
+//            print(storedTokenEntities)
+//
+//            for platform in addedPlatforms.storedTokens {
+//                let platformId = Vault.deriveUniqueKey(
+//                    platformName: platform.platform,
+//                    accountIdentifier: platform.accountIdentifier
+//                )
+//
+//                let accessToken = platform.accountTokens["access_token"] ?? ""
+//                let refreshToken = platform.accountTokens["refresh_token"] ?? ""
+//                
+//                let isStoredOnDevice = platform.isStoredOnDevice
+//                if isStoredOnDevice &&
+//                    accessToken.isEmpty &&
+//                    storedTokenEntities != nil &&
+//                    !storedTokenEntities!.contains(where: { $0.id == platformId }){
+//                    missingTokens.append(platform)
+//                }
+//                else {
+//                    if storedTokenEntities == nil || !storedTokenEntities!.contains(where: { $0.id == platformId }){
+//                        platformsToSave.append(platform)
+//                    }
+//                }
+//            }
+//            
+//            
+//            if !platformsToSave.isEmpty {
+//                try Vault.clear(context: context)
+//            }
+////            context.reset()
+//            
+//            print("[+] platforms to save: ", platformsToSave)
+//            for platform in platformsToSave {
+//                let platformId = Vault.deriveUniqueKey(
+//                    platformName: platform.platform,
+//                    accountIdentifier: platform.accountIdentifier
+//                )
+//                
+//               let accessToken = platform.accountTokens["access_token"] ?? ""
+//               let refreshToken = platform.accountTokens["refresh_token"] ?? ""
+//                    
+//                print("Access token to be saved: \(accessToken)")
+//                print("Refresh token to be saved: \(refreshToken)")
+//                
+//                
+//                let storedPlatformEntity = StoredPlatformsEntity(context: context)
+//                storedPlatformEntity.id = platformId
+//                storedPlatformEntity.name = platform.platform
+//                storedPlatformEntity.account = platform.accountIdentifier
+//                storedPlatformEntity.access_token = accessToken
+//                storedPlatformEntity.refresh_token = refreshToken
+//            }
+//            DispatchQueue.main.async {
+//                do {
+//                    if context.hasChanges {
+//                        try context.save()
+//                    }
+//                } catch {
+//                    print("[Vault] Failed to save context after refreshing entities: \(error)")
+//                }
+//            }
+//        } catch Exceptions.unauthenticatedLLT(let status) {
+//            print("[Vault] Should delete invalid llt: \(String(describing: status.message))")
+//            try Vault.resetKeystore(context: context)
+//            try DataController.resetDatabase(context: context)
+//        } catch {
+//            print("[Vault] Error fetching stored tokens: \(error)")
+//            throw error
+//        }
+//        return missingTokens
+//    }
+//    
 
     static func clear(context: NSManagedObjectContext) throws {
         print("[Vault] Clearing platforms...")
@@ -669,4 +784,6 @@ struct Vault {
 
         try Vault.resetStates(context: context)
     }
+    
+    
 }

--- a/SMSWithoutBorders-Production/Modules/Vault.swift
+++ b/SMSWithoutBorders-Production/Modules/Vault.swift
@@ -517,8 +517,15 @@ struct Vault {
                 entityToSave.refresh_token = refreshToken
             }
 
-            try context.save()
-            print("Successfully saved stored platform: \(name) (ID: \(id))")
+            DispatchQueue.main.async {
+                do {
+                    try context.save()
+                    print("Successfully saved stored platform: \(name) (ID: \(id))")
+                } catch {
+                    print(error)
+                }
+            }
+        
 
         } catch {
             print("Error saving stored platform (ID: \(id)): \(error)")
@@ -557,14 +564,6 @@ struct Vault {
                 } catch {
                     print("[Vault] Failed to store platform \(platform.accountIdentifier): \(error)")
                 }
-                
-                // Have this missingTokens thing still
-//                if platform.isStoredOnDevice &&
-//                    accessToken.isEmpty &&
-//                    storedTokenEntities != nil &&
-//                    !storedTokenEntities!.contains(where: { $0.id == platformId }){
-//                    missingTokens.append(platform)
-//                }
             }
 
         } catch Exceptions.unauthenticatedLLT(let status) {
@@ -580,91 +579,6 @@ struct Vault {
     
 
     
-//    func refreshStoredTokens(
-//        llt: String,
-//        context: NSManagedObjectContext,
-//        storedTokenEntities: FetchedResults<StoredPlatformsEntity>?
-//    ) throws -> [Vault_V1_Token] {
-//        print("[Vault] Refreshing stored platforms...")
-//        let vault = Vault()
-//        var missingTokens: [Vault_V1_Token] = []
-//        do {
-//            let addedPlatforms = try vault.listStoredEntityToken(
-//                longLiveToken: llt, migrateToDevice: shouldStorePlatformsOnDevice)
-//            
-//            var platformsToSave: [Vault_V1_Token] = []
-//            print(storedTokenEntities)
-//
-//            for platform in addedPlatforms.storedTokens {
-//                let platformId = Vault.deriveUniqueKey(
-//                    platformName: platform.platform,
-//                    accountIdentifier: platform.accountIdentifier
-//                )
-//
-//                let accessToken = platform.accountTokens["access_token"] ?? ""
-//                let refreshToken = platform.accountTokens["refresh_token"] ?? ""
-//                
-//                let isStoredOnDevice = platform.isStoredOnDevice
-//                if isStoredOnDevice &&
-//                    accessToken.isEmpty &&
-//                    storedTokenEntities != nil &&
-//                    !storedTokenEntities!.contains(where: { $0.id == platformId }){
-//                    missingTokens.append(platform)
-//                }
-//                else {
-//                    if storedTokenEntities == nil || !storedTokenEntities!.contains(where: { $0.id == platformId }){
-//                        platformsToSave.append(platform)
-//                    }
-//                }
-//            }
-//            
-//            
-//            if !platformsToSave.isEmpty {
-//                try Vault.clear(context: context)
-//            }
-////            context.reset()
-//            
-//            print("[+] platforms to save: ", platformsToSave)
-//            for platform in platformsToSave {
-//                let platformId = Vault.deriveUniqueKey(
-//                    platformName: platform.platform,
-//                    accountIdentifier: platform.accountIdentifier
-//                )
-//                
-//               let accessToken = platform.accountTokens["access_token"] ?? ""
-//               let refreshToken = platform.accountTokens["refresh_token"] ?? ""
-//                    
-//                print("Access token to be saved: \(accessToken)")
-//                print("Refresh token to be saved: \(refreshToken)")
-//                
-//                
-//                let storedPlatformEntity = StoredPlatformsEntity(context: context)
-//                storedPlatformEntity.id = platformId
-//                storedPlatformEntity.name = platform.platform
-//                storedPlatformEntity.account = platform.accountIdentifier
-//                storedPlatformEntity.access_token = accessToken
-//                storedPlatformEntity.refresh_token = refreshToken
-//            }
-//            DispatchQueue.main.async {
-//                do {
-//                    if context.hasChanges {
-//                        try context.save()
-//                    }
-//                } catch {
-//                    print("[Vault] Failed to save context after refreshing entities: \(error)")
-//                }
-//            }
-//        } catch Exceptions.unauthenticatedLLT(let status) {
-//            print("[Vault] Should delete invalid llt: \(String(describing: status.message))")
-//            try Vault.resetKeystore(context: context)
-//            try DataController.resetDatabase(context: context)
-//        } catch {
-//            print("[Vault] Error fetching stored tokens: \(error)")
-//            throw error
-//        }
-//        return missingTokens
-//    }
-//    
 
     static func clear(context: NSManagedObjectContext) throws {
         print("[Vault] Clearing platforms...")

--- a/SMSWithoutBorders-Production/Views/Components/Extensions.swift
+++ b/SMSWithoutBorders-Production/Views/Components/Extensions.swift
@@ -37,3 +37,18 @@ extension Array {
         NSOrderedSet(array: self).array.compactMap({ $0 as? Element })
     }
 }
+
+
+extension StoredPlatformsEntity {
+    var tokensExists: Bool {
+        if let aToken = access_token, let rToken = refresh_token {
+            return !aToken.isEmpty && !rToken.isEmpty
+        } else {
+            return false
+        }
+    }
+    
+    var isMissing: Bool {
+        return  self.is_stored_on_device && !self.tokensExists
+    }
+}

--- a/SMSWithoutBorders-Production/Views/Homepage/HomepageView.swift
+++ b/SMSWithoutBorders-Production/Views/Homepage/HomepageView.swift
@@ -25,7 +25,8 @@ struct HomepageView: View {
     private var doNotNotifyOfMissingTokens: Bool = false
     
     @AppStorage(SettingsKeys.SETTINGS_NOTIFY_OF_NEW_FEATURE)
-    var notifyOfNewFeature: Bool = true
+    private var notifyOfNewFeature: Bool = true
+    
     @State private var showNewFeatureAlert: Bool = false
     var newFeatureAlertTitle: String = "New Feature Alert!"
     var newFeatureAlertMessage: String = "You can now request for tokens of your OAuth2.0 accounts to be stored on your device by going to Settings > Security"

--- a/SMSWithoutBorders-Production/Views/Inbox/DecryptMessageView.swift
+++ b/SMSWithoutBorders-Production/Views/Inbox/DecryptMessageView.swift
@@ -153,10 +153,7 @@ struct DecryptMessageView: View {
         .navigationTitle("Decrypt Message")
     }
 
-    //Might move
-
     func retirieveTwitterTokens(reply: String) {
-
         alertTitle = "Error"
         alertMessage = "Failed to process request"
 
@@ -166,14 +163,21 @@ struct DecryptMessageView: View {
             print("Successfully decoded the twitter reply: \(decodedString)")
 
             do {
-                //Extract the refresh tokens
-                let refreshToken = decodedString
-                let platformName = "twitter"
+                // Extract the refresh tokens
+                // Format for the returned string is like so
+                // accountIdentifier:refreshToken
+                let platformName: String  = "twitter"
+                let refreshToken: String = String(decodedString.split(separator: ":")[1])
+                let accountIdentifier: String = String(decodedString.split(separator: ":")[0])
 
                 let fetchRequest: NSFetchRequest<StoredPlatformsEntity> = StoredPlatformsEntity.fetchRequest()
                 fetchRequest.predicate = NSPredicate(format: "name == %@", platformName)
 
-                let existingEntity = try context.fetch(fetchRequest).first
+                let accountsForPlatform: [StoredPlatformsEntity] = try context.fetch(fetchRequest)
+                
+                let existingEntity = accountsForPlatform.first {$0.account ?? "" == accountIdentifier}
+                
+                print("Existing Twitter account before refresh token update: \(existingEntity)")
 
                 if let entityToUpdate = existingEntity {
                     do {
@@ -189,17 +193,18 @@ struct DecryptMessageView: View {
                         print("Successfully updated the Twitter refresh token")
                         alertTitle = "Success"
                         alertMessage = "Successfully updated the Twitter refresh token"
+                        textBody = ""
+                        dismiss()
+                        
 
                     } catch {
                         alertTitle = "Failed"
                         alertMessage = "Unable to update the refresh token for Twitter"
                         print("Unable to update the refresh token for twitter: \(error)")
-
                     }
                 } else {
                     alertTitle = "Failed"
                     alertMessage = "Twitter platform not found, please add it first"
-
                 }
             } catch {
                 alertTitle = "Error"
@@ -211,7 +216,6 @@ struct DecryptMessageView: View {
             alertTitle = "Error"
             alertMessage = "Failed to decode the message"
         }
-
         showAlert = true
     }
 }

--- a/SMSWithoutBorders-Production/Views/Inbox/DecryptMessageView.swift
+++ b/SMSWithoutBorders-Production/Views/Inbox/DecryptMessageView.swift
@@ -5,6 +5,7 @@
 //  Created by Nui Lewis on 26/03/2025.
 //
 
+import CoreData
 import SwiftUI
 
 struct DecryptMessageView: View {
@@ -12,90 +13,206 @@ struct DecryptMessageView: View {
     @Environment(\.managedObjectContext) var context
 
     @State var textBody = ""
-    @State var placeHolder = String(localized:"Click to paste...")
+    @State var placeHolder = String(localized: "Click to paste...")
+
+    @State var showAlert: Bool = false
+    @State var alertMessage: String = ""
+    @State var alertTitle: String = ""
 
     var body: some View {
-        VStack {
+        ScrollView {
             VStack {
-                Text("Paste encrypted text into this box...")
-                    .font(.subheadline)
-                    .padding(.bottom, 32)
+                VStack {
+                    Text("Paste encrypted text into this box...")
+                        .font(.subheadline)
+                        .padding(.bottom, 24)
 
-                Text(String(localized:"An example message...\n\nRelaySMS Reply Please paste this entire message in your RelaySMS app\n3AAAAGUoAAAAAAAAAAAAAADN2pJG+1g5bNt1ziT84plbYcgwbbp+PbQHBf7ekxkOO...", comment: "Shows an explain message which can be pasted into the inbox view and decrypted"))
+                    Text(
+                        String(
+                            localized:
+                                "An example message...\n\nRelaySMS Reply Please paste this entire message in your RelaySMS app\n3AAAAGUoAAAAAAAAAAAAAADN2pJG+1g5bNt1ziT84plbYcgwbbp+PbQHBf7ekxkOO...",
+                            comment:
+                                "Shows an explain message which can be pasted into the inbox view and decrypted"
+                        )
+                    )
                     .font(.caption2)
                     .multilineTextAlignment(.leading)
                     .foregroundStyle(.secondary)
-            }
-            .padding(.bottom, 24)
+                }
+                .padding(.bottom, 24)
 
-            VStack {
-                ZStack {
-                    if self.textBody.isEmpty {
-                        TextEditor(text: $placeHolder)
+                VStack {
+                    ZStack {
+                        if self.textBody.isEmpty {
+                            TextEditor(text: $placeHolder)
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                                .disabled(true)
+                                .frame(height: 200)
+                        }
+                        TextEditor(text: $textBody)
                             .font(.caption)
-                            .foregroundColor(.secondary)
-                            .disabled(true)
+                            .opacity(self.textBody.isEmpty ? 0.25 : 1)
+                            .textFieldStyle(PlainTextFieldStyle())
+                            .frame(height: 200)
+
                     }
-                    TextEditor(text: $textBody)
-                        .font(.caption)
-                        .opacity(self.textBody.isEmpty ? 0.25 : 1)
-                        .textFieldStyle(PlainTextFieldStyle())
+                    .padding()
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 16)
+                            .stroke(
+                                textBody.isEmpty
+                                    ? RelayColors.colorScheme.onSurface.opacity(
+                                        0.1) : RelayColors.colorScheme.primary,
+                                lineWidth: 1)
+                    )
+                    .padding(.bottom, 24)
+                 
+
+                }.alert(alertTitle, isPresented: $showAlert) {
+                } message: {
+                    Text(alertMessage)
                 }
-                .padding()
-                .overlay(
-                    RoundedRectangle(cornerRadius: 16)
-                        .stroke(textBody.isEmpty ? RelayColors.colorScheme.onSurface.opacity(0.1) : RelayColors.colorScheme.primary, lineWidth: 2)
-                )
-            }
 
-            VStack {
-                Button {
-                    do {
-                        let decryptedText = try Bridges.decryptIncomingMessages(
-                            context: context,
-                            text: textBody
-                        )
-                        print(decryptedText)
-                        DispatchQueue.background(background: {
-                            let date = Int(Date().timeIntervalSince1970)
+                HStack {
+                    Button {
+                        do {
+                            let decryptedText =
+                                try Bridges.decryptIncomingMessages(
+                                    context: context,
+                                    text: textBody
+                                )
+                            print(decryptedText)
+                            DispatchQueue.background(
+                                background: {
+                                    let date = Int(Date().timeIntervalSince1970)
 
-                            var messageEntities = MessageEntity(context: context)
-                            messageEntities.id = UUID()
-                            messageEntities.platformName = Bridges.SERVICE_NAME
-                            messageEntities.fromAccount = decryptedText.fromAccount
-                            messageEntities.toAccount = ""
-                            messageEntities.cc = decryptedText.cc
-                            messageEntities.bcc = decryptedText.bcc
-                            messageEntities.subject = decryptedText.subject
-                            messageEntities.body = decryptedText.body
-                            messageEntities.date = decryptedText.date
-                            messageEntities.type = Bridges.SERVICE_NAME_INBOX
+                                    var messageEntities = MessageEntity(
+                                        context: context)
+                                    messageEntities.id = UUID()
+                                    messageEntities.platformName =
+                                        Bridges.SERVICE_NAME
+                                    messageEntities.fromAccount =
+                                        decryptedText.fromAccount
+                                    messageEntities.toAccount = ""
+                                    messageEntities.cc = decryptedText.cc
+                                    messageEntities.bcc = decryptedText.bcc
+                                    messageEntities.subject =
+                                        decryptedText.subject
+                                    messageEntities.body = decryptedText.body
+                                    messageEntities.date = decryptedText.date
+                                    messageEntities.type =
+                                        Bridges.SERVICE_NAME_INBOX
 
-                            DispatchQueue.main.async {
-                                do {
-                                    try context.save()
-                                } catch {
-                                    print("Failed to save message entity: \(error)")
-                                }
-                            }
-                        }, completion: {
-                            dismiss()
-                        })
-                    } catch {
-                        print("Error decrypting: \(error)")
+                                    DispatchQueue.main.async {
+                                        do {
+                                            try context.save()
+                                        } catch {
+                                            print(
+                                                "Failed to save message entity: \(error)"
+                                            )
+                                        }
+                                    }
+                                },
+                                completion: {
+                                    dismiss()
+                                })
+                        } catch {
+                            print("Error decrypting: \(error)")
+                        }
+                    } label: {
+                        Text("Decrypt message")
                     }
-                } label: {
-                    Text("Decrypt message")
+                    .buttonStyle(.relayButton(variant: .primary))
+                    .controlSize(.large)
+                    .tint(.accentColor)
+                    .disabled(textBody.isEmpty)
+
+                    Button {
+                        if !textBody.isEmpty {
+                            retirieveTwitterTokens(reply: textBody)
+                        } else {
+                            print("Text body is empty")
+                            showAlert = true
+                            alertTitle = "Error"
+                            alertMessage = "Please enter a message to decrypt"
+                        }
+
+                    } label: {
+                        Text("Update Twitter")
+                    }
+                    .buttonStyle(.relayButton(variant: .secondary))
+                    .controlSize(.large)
+                    .tint(.accentColor)
+                    .disabled(textBody.isEmpty)
                 }
-                .buttonStyle(.relayButton(variant: .primary))
-                .controlSize(.large)
-                .tint(.accentColor)
-                .disabled(textBody.isEmpty)
-                .padding(.bottom, 48)
-            }
+            }.padding()
+
         }
+
         .navigationTitle("Decrypt Message")
-        .padding()
+    }
+
+    //Might move
+
+    func retirieveTwitterTokens(reply: String) {
+
+        alertTitle = "Error"
+        alertMessage = "Failed to process request"
+
+        let decodedReply = String(
+            data: Data(base64Encoded: reply) ?? Data(), encoding: .utf8)
+        if let decodedString = decodedReply, !decodedString.isEmpty {
+            print("Successfully decoded the twitter reply: \(decodedString)")
+
+            do {
+                //Extract the refresh tokens
+                let refreshToken = decodedString
+                let platformName = "twitter"
+
+                let fetchRequest: NSFetchRequest<StoredPlatformsEntity> = StoredPlatformsEntity.fetchRequest()
+                fetchRequest.predicate = NSPredicate(format: "name == %@", platformName)
+
+                let existingEntity = try context.fetch(fetchRequest).first
+
+                if let entityToUpdate = existingEntity {
+                    do {
+                        try Vault.saveStoredPlatform(
+                            context: context,
+                            id: entityToUpdate.id ?? "",
+                            name: entityToUpdate.name ?? "",
+                            account: entityToUpdate.account ?? "",
+                            isStoredOnDevice: entityToUpdate.is_stored_on_device,
+                            accessToken: existingEntity?.access_token,
+                            refreshToken: refreshToken
+                        )
+                        print("Successfully updated the Twitter refresh token")
+                        alertTitle = "Success"
+                        alertMessage = "Successfully updated the Twitter refresh token"
+
+                    } catch {
+                        alertTitle = "Failed"
+                        alertMessage = "Unable to update the refresh token for Twitter"
+                        print("Unable to update the refresh token for twitter: \(error)")
+
+                    }
+                } else {
+                    alertTitle = "Failed"
+                    alertMessage = "Twitter platform not found, please add it first"
+
+                }
+            } catch {
+                alertTitle = "Error"
+                alertMessage = "Failed to fetch Twitter platform: \(error.localizedDescription)"
+                print(error)
+            }
+
+        } else {
+            alertTitle = "Error"
+            alertMessage = "Failed to decode the message"
+        }
+
+        showAlert = true
     }
 }
 

--- a/SMSWithoutBorders-Production/Views/Inbox/DecryptMessageView.swift
+++ b/SMSWithoutBorders-Production/Views/Inbox/DecryptMessageView.swift
@@ -157,11 +157,12 @@ struct DecryptMessageView: View {
         alertTitle = "Error"
         alertMessage = "Failed to process request"
 
-        let decodedReply = String(
-            data: Data(base64Encoded: reply) ?? Data(), encoding: .utf8)
-        if let decodedString = decodedReply, !decodedString.isEmpty {
-            print("Successfully decoded the twitter reply: \(decodedString)")
 
+            
+        let extractedBase64String = extractEncryptedText(from: reply);
+
+        if let base64String = extractedBase64String, !base64String.isEmpty {
+            let decodedString = decodeBase64String(from: base64String)
             do {
                 // Extract the refresh tokens
                 // Format for the returned string is like so
@@ -192,7 +193,7 @@ struct DecryptMessageView: View {
                         )
                         print("Successfully updated the Twitter refresh token")
                         alertTitle = "Success"
-                        alertMessage = "Successfully updated the Twitter refresh token"
+                        alertMessage = "Successfully updated the Twitter refresh token for @\(accountIdentifier)"
                         textBody = ""
                         dismiss()
                         
@@ -204,14 +205,13 @@ struct DecryptMessageView: View {
                     }
                 } else {
                     alertTitle = "Failed"
-                    alertMessage = "Twitter platform not found, please add it first"
+                    alertMessage = "Twitter account for identifier \(accountIdentifier) not found, please add it first"
                 }
             } catch {
                 alertTitle = "Error"
                 alertMessage = "Failed to fetch Twitter platform: \(error.localizedDescription)"
                 print(error)
             }
-
         } else {
             alertTitle = "Error"
             alertMessage = "Failed to decode the message"

--- a/SMSWithoutBorders-Production/Views/PlatformComposeViews/SelectAccountSheetView.swift
+++ b/SMSWithoutBorders-Production/Views/PlatformComposeViews/SelectAccountSheetView.swift
@@ -19,18 +19,11 @@ struct AccountListItem: View {
 
     init(platform: StoredPlatformsEntity?,
          context: NSManagedObjectContext,
-         platformsVault: Vault_V1_Token? = nil,
          missing: Bool = false
     ) {
-        if platformsVault != nil {
-            self.accountName = platformsVault?.accountIdentifier ?? "Unknown account"
-            self.platformName = platformsVault?.platform ?? ""
-        }
-        else {
             self.platform = platform
             self.accountName = platform?.account ?? "Unknown account"
             self.platformName = platform?.name ?? "Unknown platform"
-        }
         self.platformIsTwitter = platformName == "twitter"
         self.context = context
         self.missing = missing

--- a/SMSWithoutBorders-Production/Views/PlatformComposeViews/SelectAccountSheetView.swift
+++ b/SMSWithoutBorders-Production/Views/PlatformComposeViews/SelectAccountSheetView.swift
@@ -20,7 +20,7 @@ struct AccountListItem: View {
     init(platform: StoredPlatformsEntity?,
          context: NSManagedObjectContext,
          platformsVault: Vault_V1_Token? = nil,
-         missing: Bool = false,
+         missing: Bool = false
     ) {
         if platformsVault != nil {
             self.accountName = platformsVault?.accountIdentifier ?? "Unknown account"
@@ -109,18 +109,21 @@ struct SelectAccountSheetView: View {
         storedPlatforms: FetchedResults<StoredPlatformsEntity>,
         context: NSManagedObjectContext
     ) -> [StoredPlatformsEntity] {
-        print("Searching for platforms which can publish")
+        print("[SelectAccountSheetView] Searching for platforms which can publish")
         var publishableAccounts: [StoredPlatformsEntity] = []
         for account in storedPlatforms {
-            publishableAccounts.append(account)
+            if !account.isMissing{
+                publishableAccounts.append(account)
+            }
         }
         return publishableAccounts
     }
+    
 
     var body: some View {
         NavigationView {
             VStack(alignment: .leading) {
-                List(storedPlatforms, id: \.self) { platform in
+                List(publishablePlatforms, id: \.self) { platform in
                     Button(action: {
                         if fromAccount != nil {
                             fromAccount = platform.account!
@@ -144,15 +147,15 @@ struct SelectAccountSheetView: View {
                     }
                 }
             }
-//            .onAppear {
-//                publishablePlatforms = getPublishablePlatorms(
-//                        storedPlatforms: storedPlatforms, context: context)
-//                
-//                allStoredPlatforms = []
-//                for platform in storedPlatforms {
-//                    allStoredPlatforms.append(platform)
-//                }
-//            }
+            .onAppear {
+                allStoredPlatforms = []
+                for platform in storedPlatforms {
+                    allStoredPlatforms.append(platform)
+                }
+                
+                publishablePlatforms = getPublishablePlatorms(
+                        storedPlatforms: storedPlatforms, context: context)
+            }
         }
     }
 }

--- a/SMSWithoutBorders-Production/Views/Platforms/Components/PlatformCard.swift
+++ b/SMSWithoutBorders-Production/Views/Platforms/Components/PlatformCard.swift
@@ -14,6 +14,7 @@ struct PlatformCard: View {
         keyPath: \StoredPlatformsEntity.name,
         ascending: true)]
     ) var storedPlatforms: FetchedResults<StoredPlatformsEntity>
+    @State private var publishablePlatforms: [StoredPlatformsEntity] = []
 
     @State var sheetIsPresented: Bool = false
     @State var isEnabled: Bool = false
@@ -86,6 +87,7 @@ struct PlatformCard: View {
             }
         }
         .onAppear {
+            getPublishablePlatforms()
             isEnabled = platform != nil ? isStored(platformEntity: platform!) : true
         }
     }
@@ -115,11 +117,22 @@ struct PlatformCard: View {
             return Publisher.ServiceComposeTypeDescriptions.BRIDGE.localizedValue()
         }
     }
-
-    func isStored(platformEntity: PlatformsEntity) -> Bool {
-        return storedPlatforms.contains(where: { $0.name == platformEntity.name })
+    
+    func getPublishablePlatforms(){
+        publishablePlatforms.removeAll()
+        for account in storedPlatforms {
+            if !account.isMissing {
+                publishablePlatforms.append(account)
+            }
+        }
     }
-
+    
+    func isStored(platformEntity: PlatformsEntity) -> Bool {
+        return publishablePlatforms.contains(where: {
+            print("is enabled from platform card: \($0.name == platform?.name) ")
+            return $0.name == platform?.name
+        })
+    }
 
 }
 

--- a/SMSWithoutBorders-Production/Views/Platforms/Components/PlatformDetailsBottomsheet.swift
+++ b/SMSWithoutBorders-Production/Views/Platforms/Components/PlatformDetailsBottomsheet.swift
@@ -27,6 +27,7 @@ struct PlatformDetailsBottomsheet: View {
     @State var errorMessage: String = ""
 
     var platform: PlatformsEntity?
+    
     @FetchRequest(sortDescriptors: [NSSortDescriptor(
         keyPath: \StoredPlatformsEntity.name,
         ascending: true)]

--- a/SMSWithoutBorders-Production/Views/Platforms/PlatformsView.swift
+++ b/SMSWithoutBorders-Production/Views/Platforms/PlatformsView.swift
@@ -16,16 +16,20 @@ enum PlatformsRequestedType: CaseIterable {
 struct PlatformsView: View {
     @Environment(\.managedObjectContext) var context
 
-    @FetchRequest(sortDescriptors: [NSSortDescriptor(
-        keyPath: \PlatformsEntity.name,
-        ascending: true)]
+    @FetchRequest(sortDescriptors: [
+        NSSortDescriptor(
+            keyPath: \PlatformsEntity.name,
+            ascending: true)
+    ]
     ) var platforms: FetchedResults<PlatformsEntity>
 
-    @FetchRequest(sortDescriptors: [NSSortDescriptor(
-        keyPath: \StoredPlatformsEntity.name,
-        ascending: true)]
+    @FetchRequest(sortDescriptors: [
+        NSSortDescriptor(
+            keyPath: \StoredPlatformsEntity.name,
+            ascending: true)
+    ]
     ) var storedPlatforms: FetchedResults<StoredPlatformsEntity>
-    
+
     @State private var publishablePlatforms: [StoredPlatformsEntity] = []
 
     @State private var id = UUID()
@@ -50,7 +54,7 @@ struct PlatformsView: View {
             ScrollView {
                 VStack(alignment: .leading) {
                     Text("Use your RelaySMS account")
-                        .font(.caption)
+                        .font(RelayTypography.titleSmall)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(.bottom, 10)
 
@@ -58,7 +62,8 @@ struct PlatformsView: View {
                         isEnabled: true,
                         composeNewMessageRequested: $composeNewMessageRequested,
                         platformRequestType: $requestType,
-                        composeViewRequested: getBindingComposeVariable(type: "email"),
+                        composeViewRequested: getBindingComposeVariable(
+                            type: "email"),
                         parentRefreshRequested: $refreshRequested,
                         requestedPlatformName: $requestedPlatformName,
                         platform: nil,
@@ -68,26 +73,49 @@ struct PlatformsView: View {
 
                     HStack {
                         Text("Use your online accounts")
-                            .font(.caption)
+                            .font(RelayTypography.titleSmall)
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .padding(.bottom, 10)
                     }
 
-                   if platforms.isEmpty {
-                       Text("No online platforms saved yet...")
-                       Button("Load Platforms") {
-                           Publisher.refreshPlatforms(context: context)
-                       }.buttonStyle(.relayButton(variant: .text))
-                       
-          
+                    if requestType == .compose && publishablePlatforms.isEmpty {
+                        VStack(alignment: .center) {
+                            Spacer().frame(height: 32)
+                            Image(systemName: "folder.badge.questionmark")
+                                .font(.system(size: 64))
+                                .symbolRenderingMode(.hierarchical)
+                                .foregroundStyle(
+                                    RelayColors.colorScheme.primary)
+                            Text(
+                                "No online platforms saved yet... You can save more platforms below"
+                            ).padding(16)
+                                .multilineTextAlignment(.center)
+                                .frame(alignment: Alignment.center)
+                        }
+
+                    }
+                    if platforms.isEmpty {
+                        VStack(alignment: .center, spacing: 16) {
+                            Text("No online platforms saved yet...").font(
+                                RelayTypography.bodyMedium
+                            ).multilineTextAlignment(.center).frame(
+                                alignment: Alignment.center)
+                            Button("Load Platforms") {
+                                Publisher.refreshPlatforms(context: context)
+                            }.buttonStyle(.relayButton(variant: .text)).frame(
+                                alignment: .center)
+                        }
+
                     } else {
-                        LazyVGrid(columns: columns, alignment: .leading, spacing: 20) {
+                        LazyVGrid(
+                            columns: columns, alignment: .leading, spacing: 20
+                        ) {
                             if requestType == .compose {
-                                ForEach(filterForStoredPlatforms(), id: \.name) { item in
+                                ForEach(filterForStoredPlatforms(), id: \.name)
+                                { item in
                                     createPlatformCard(for: item)
                                 }
-                            }
-                            else {
+                            } else {
                                 ForEach(platforms, id: \.name) { item in
                                     createPlatformCard(for: item)
                                 }
@@ -95,33 +123,35 @@ struct PlatformsView: View {
                         }
                     }
 
-                }
-                .id(id)
-                .onChange(of: refreshRequested) { refresh in
-                    if refresh {
-                        print("refreshing....")
-                        id = UUID()
-                    }
-                }
-
-                VStack(alignment: .center) {
-                    Button {
-                        requestType = requestType == .compose ? .available : .compose
-                    } label: {
-                        if requestType == .compose {
-                            Text("Save more platforms...")
-                        } else {
-                            Text("Send new message...")
+                }.padding([.leading, .trailing], 16)
+                    .id(id)
+                    .onChange(of: refreshRequested) { refresh in
+                        if refresh {
+                            print("refreshing....")
+                            id = UUID()
                         }
                     }
-                    .padding(.top, 32)
-                }
+
+                Button {
+                    requestType =
+                        requestType == .compose ? .available : .compose
+                } label: {
+                    if requestType == .compose {
+                        Text("Save more platforms...")
+                    } else {
+                        Text("Send new message...")
+                    }
+                }.buttonStyle(.relayButton(variant: .secondary))
+                    .padding([.leading, .trailing], 16)
+                    .padding([.top, .bottom], 32)
+
             }
             .navigationTitle(getRequestTypeText(type: requestType))
-            .padding(16)
         }.onAppear {
             if platforms.count == 0 {
-                print("[PlatformsView - onAppear]: No platforms found, refreshing....")
+                print(
+                    "[PlatformsView - onAppear]: No platforms found, refreshing...."
+                )
                 Publisher.refreshPlatforms(context: context)
             } else {
                 getPublishablePlatforms()
@@ -136,45 +166,44 @@ struct PlatformsView: View {
         var _storedPlatforms: Set<PlatformsEntity> = []
 
         for platform in platforms {
-            if publishablePlatforms.contains(where: { $0.name == platform.name }) {
+            if publishablePlatforms.contains(where: { $0.name == platform.name }
+            ) {
                 _storedPlatforms.insert(platform)
             }
         }
         return Array(_storedPlatforms)
     }
-    
+
     private func createPlatformCard(for item: PlatformsEntity) -> some View {
         let serviceType = item.service_type ?? ""
-         let composeBinding = getBindingComposeVariable(type: serviceType)
-         let platformServiceType = getServiceType(type: serviceType)
-         
-         // Check if paltform is publishable
-         var isEnabled: Bool = false
-    
-         let storedPlatform = publishablePlatforms.first {
-             $0.name == item.name
-         }
-         if let account = storedPlatform {
-             isEnabled = true
-         }
-        print("[create platform card], is platform enabled: \(isEnabled) for \(storedPlatform)")
+        let composeBinding = getBindingComposeVariable(type: serviceType)
+        let platformServiceType = getServiceType(type: serviceType)
 
-         return PlatformCard(
-             isEnabled: isEnabled,
-             composeNewMessageRequested: $composeNewMessageRequested,
-             platformRequestType: $requestType,
-             composeViewRequested: composeBinding,
-             parentRefreshRequested: $refreshRequested,
-             requestedPlatformName: $requestedPlatformName,
-             platform: item,
-             serviceType: platformServiceType,
-             callback: callback
-         )
-     }
+        // Check if paltform is publishable
+        var isEnabled: Bool = false
+
+        let storedPlatform = publishablePlatforms.first {
+            $0.name == item.name
+        }
+        if storedPlatform != nil {
+            isEnabled = true
+        }
+        return PlatformCard(
+            isEnabled: isEnabled,
+            composeNewMessageRequested: $composeNewMessageRequested,
+            platformRequestType: $requestType,
+            composeViewRequested: composeBinding,
+            parentRefreshRequested: $refreshRequested,
+            requestedPlatformName: $requestedPlatformName,
+            platform: item,
+            serviceType: platformServiceType,
+            callback: callback
+        )
+    }
 
     func getBindingComposeVariable(type: String) -> Binding<Bool> {
-        @State var defaultNil : Bool? = false
-        switch(type) {
+        @State var defaultNil: Bool? = false
+        switch type {
         case Publisher.ServiceTypes.EMAIL.rawValue:
             return $composeEmailRequested
         case Publisher.ServiceTypes.MESSAGE.rawValue:
@@ -185,8 +214,8 @@ struct PlatformsView: View {
             return $composeEmailRequested
         }
     }
-    
-    func getPublishablePlatforms(){
+
+    func getPublishablePlatforms() {
         publishablePlatforms.removeAll()
         for account in storedPlatforms {
             if !account.isMissing {
@@ -196,21 +225,18 @@ struct PlatformsView: View {
     }
 
     func getRequestTypeText(type: PlatformsRequestedType) -> String {
-        switch(type) {
+        switch type {
         case .compose:
-            return String(localized:"Send a message")
+            return String(localized: "Send a message")
         case .revoke:
-            return String(localized:"Remove a platform")
+            return String(localized: "Remove a platform")
         default:
-            return String(localized:"Available Platforms")
+            return String(localized: "Available Platforms")
         }
     }
-    
-
-
 
     func getServiceType(type: String) -> Publisher.ServiceTypes {
-        switch(type) {
+        switch type {
         case Publisher.ServiceTypes.EMAIL.rawValue:
             return Publisher.ServiceTypes.EMAIL
         case Publisher.ServiceTypes.MESSAGE.rawValue:
@@ -223,13 +249,11 @@ struct PlatformsView: View {
         }
     }
 
-
 }
-
 
 struct Platforms_Preview: PreviewProvider {
     static var previews: some View {
-        
+
         let container = createInMemoryPersistentContainer()
         populateMockData(container: container)
 
@@ -249,7 +273,7 @@ struct Platforms_Preview: PreviewProvider {
             composeMessageRequested: $composeMessageRequested,
             composeEmailRequested: $composeEmailRequested
         )
-            .environment(\.managedObjectContext, container.viewContext)
+        .environment(\.managedObjectContext, container.viewContext)
     }
 }
 
@@ -277,6 +301,3 @@ struct Platforms_Preview: PreviewProvider {
 //            .environment(\.managedObjectContext, container.viewContext)
 //    }
 //}
-
-
-

--- a/SMSWithoutBorders-Production/Views/Settings/SecuritySettingsView.swift
+++ b/SMSWithoutBorders-Production/Views/Settings/SecuritySettingsView.swift
@@ -99,8 +99,14 @@ struct SecuritySettingsView: View {
                         if newValue {
                             migratePlatforms()
                         } else {
-                            let migrationAttemptedPreviously = storedPlatforms.contains {
-                                !$0.access_token!.isEmpty}
+                            var migrationAttemptedPreviously = false
+                            for account in storedPlatforms {
+                                if account.is_stored_on_device {
+                                    migrationAttemptedPreviously = true
+                                    break
+                                }
+                            }
+                      
                             if migrationAttemptedPreviously {
                                 activeAlertType = .disableLocalTokenStorageConfirmation
                                 showAlert = true
@@ -221,8 +227,6 @@ struct SecuritySettingsView: View {
 
     func logout() {
         logoutAccount(context: viewContext)
-        // Delete all stored tokens when logging out
-//        StoredTokensEntityManager(context: viewContext).deleteAllStoredTokens()
         do {
             isLoggedIn = try !Vault.getLongLivedToken().isEmpty
         } catch {
@@ -242,8 +246,6 @@ struct SecuritySettingsView: View {
                         longLiveToken: llt,
                         storedTokenEntities: storedPlatforms,
                         platforms: platforms)
-                    // Delete all stored tokens when logging out
-//                    StoredTokensEntityManager(context: viewContext).deleteAllStoredTokens()
                 } catch {
                     print("Error deleting: \(error)")
                 }

--- a/SMSWithoutBorders-Production/Views/Settings/SecuritySettingsView.swift
+++ b/SMSWithoutBorders-Production/Views/Settings/SecuritySettingsView.swift
@@ -13,6 +13,8 @@ struct SettingsKeys {
     public static let SETTINGS_STORE_PLATFORMS_ON_DEVICE: String =
         "SETTINGS_STORE_PLATFORMS_ON_DEVICE"
     public static let SETTINGS_DO_NOT_NOTIFY_OF_MISSING_TOKENS: String = "SETTINGS_DO_NOT_NOTIFY_OF_MISSING_TOKENS"
+    
+    public static let SETTINGS_NOTIFY_OF_NEW_FEATURE: String = "SETTINGS_NOTIFY_OF_NEW_FEATURE"
 }
 
 enum SecurityAlertType {


### PR DESCRIPTION
Preparing for release
- Add a feature to allow for the extraction of the Twitter refresh token from the delivery message. Make it generic so it extracts the base64 String for any message format or text blob, regardless of message format 
- Add notification of new feature
- Only show publishable platforms as enabled in `PlatformsView`, and in `SelectAccountSheetView`(Only when sending a message)
- Fix issue where platforms fetch requests are not properly loading in text compose views, when fetch requests are run in the init method, causing `[]` to be returned, causing the app to crash when trying to post in `TextComposeView.`
- Ensure core data context are saved on the main thread in `vault` and `publisher`
- Update UI in `PlatformsView`
- Add translations for new strings